### PR TITLE
M2M: Fix incorrect timing constraint

### DIFF
--- a/CORE/CORE-R3.xdc
+++ b/CORE/CORE-R3.xdc
@@ -55,7 +55,7 @@ set_false_path -from [get_clocks qnice_clk]       -to [get_clocks tmds_720p_clk]
 
 ## Assume the HDMI output is 720p, which is the fastest clock.
 ## No need to do timing analysis on the slower HDMI clocks as well.
-set_case_analysis 0 [get_nets M2M/i_framework/i_clk_m2m/hdmi_clk_sel_i]
+set_case_analysis 0 [get_nets M2M/i_framework/i_clk_m2m/hdmi_clk_sel]
 
 ## The high level reset signals are slow enough so that we can afford a false path
 set_false_path -from [get_pins M2M/i_framework/i_reset_manager/reset_m2m_n_o_reg/C]

--- a/M2M/vhdl/clk_m2m.vhd
+++ b/M2M/vhdl/clk_m2m.vhd
@@ -70,7 +70,16 @@ signal hdmi_576p_locked   : std_logic;
 
 signal sys_counter        : natural range 0 to 99_999_999;
 
+-- Prevent Vivado from optimizing/renaming the signal hdmi_clk_sel_i
+-- A separate internal signal is needed, because the "keep" attribute
+-- does not work on ports, see Vivado Design Suite Properties Reference Guide (UG912).
+signal hdmi_clk_sel       : std_logic;
+attribute keep : string;
+attribute keep of hdmi_clk_sel : signal is "true";
+
 begin
+
+   hdmi_clk_sel <= hdmi_clk_sel_i;
 
    -------------------------------------------------------------------------------------
    -- Generate QNICE and HyperRAM clock
@@ -297,7 +306,7 @@ begin
 
    tmds_clk_bufgmux : BUFGMUX_CTRL
       port map (
-         S  => hdmi_clk_sel_i,
+         S  => hdmi_clk_sel,
          I0 => tmds_720p_clk_mmcm,
          I1 => tmds_576p_clk_mmcm,
          O => tmds_clk_o
@@ -305,7 +314,7 @@ begin
 
    hdmi_clk_bufgmux : BUFGMUX_CTRL
       port map (
-         S  => hdmi_clk_sel_i,
+         S  => hdmi_clk_sel,
          I0 => hdmi_720p_clk_mmcm,
          I1 => hdmi_576p_clk_mmcm,
          O => hdmi_clk_o


### PR DESCRIPTION
In the file CORE-R3.xdc the line 58 with "set_case_analysis" does not correctly find the clock select input. This is because Vivado has internally renamed the port. This fix prevents this renaming, such that the constraint works again.